### PR TITLE
Support comma-separated CORS origins

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,5 @@
-﻿from typing import List, Optional, Union
-from pydantic import AnyHttpUrl
+from typing import List, Optional, Union
+from pydantic import AnyHttpUrl, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
@@ -7,7 +7,7 @@ class Settings(BaseSettings):
 
     APP_NAME: str = "QR Access Control API"
     DATABASE_URL: str = "sqlite:///./qrac.db"
-    CORS_ORIGINS: List[str] = ["http://localhost:5173", "http://127.0.0.1:5173"]
+    CORS_ORIGINS: Union[List[str], str] = ["http://localhost:5173", "http://127.0.0.1:5173"]
     QR_BASE_URL: Optional[Union[AnyHttpUrl, str]] = None
 
     SMTP_HOST: str = ""
@@ -18,12 +18,11 @@ class Settings(BaseSettings):
     MAIL_FROM: str = ""
     MAIL_FROM_NAME: str = "QR Access Control"
 
+    @field_validator("CORS_ORIGINS", mode="before")
+    @classmethod
+    def _assemble_cors_origins(cls, v: Union[str, List[str]]) -> List[str]:
+        if isinstance(v, str):
+            return [origin.strip() for origin in v.split(",") if origin]
+        return v
+
 settings = Settings()
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary
- ensure `CORS_ORIGINS` env var accepts comma-separated values

## Testing
- `python -m uvicorn app.main:app --reload`
- `python - <<'PY'
from app.config import settings
print(settings.CORS_ORIGINS)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68af19c991308326a033bec86af2d0af