### PR TITLE
Improve front-end design and event creation

### DIFF
--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -1,23 +1,32 @@
-﻿from typing import List
+from typing import List
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import select, Session
+
 from ..models import Event
 from ..schemas import EventCreate, EventRead
 from ..deps import session_dep
 
+
 router = APIRouter(prefix="/events", tags=["events"])
 
-@router.post("/", response_model=EventRead)
+
+@router.post("/", response_model=EventRead, status_code=201)
 def create_event(payload: EventCreate, session: Session = Depends(session_dep)):
     try:
+        if not payload.name.strip():
+            raise HTTPException(status_code=400, detail="name is required")
         event = Event(name=payload.name, date=payload.date)
         session.add(event)
         session.commit()
         session.refresh(event)
         return EventRead.model_validate(event)
+    except HTTPException:
+        raise
     except Exception as e:
         session.rollback()
         raise HTTPException(status_code=500, detail=f"create_event error: {e}")
+
 
 @router.get("/", response_model=List[EventRead])
 def list_events(session: Session = Depends(session_dep)):
@@ -26,3 +35,4 @@ def list_events(session: Session = Depends(session_dep)):
         return [EventRead.model_validate(ev) for ev in events]
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"list_events error: {e}")
+

--- a/qrac/src/App.css
+++ b/qrac/src/App.css
@@ -1,42 +1,35 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+/* Basic layout styling for the demo front-end */
+
+.container {
+  max-width: 900px;
+  margin: 40px auto;
+  font-family: system-ui, sans-serif;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.section {
+  padding: 16px;
+  border: 1px solid #eee;
+  border-radius: 12px;
+  margin-bottom: 16px;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.form {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.input {
+  flex: 1;
+  padding: 8px;
 }
 
-.card {
-  padding: 2em;
+.button {
+  padding: 8px 12px;
 }
 
-.read-the-docs {
-  color: #888;
+.events-list li,
+.guest-list li {
+  margin-bottom: 8px;
 }
+

--- a/qrac/src/App.jsx
+++ b/qrac/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
+import "./App.css";
 
-const API = import.meta.env.VITE_API_URL ?? "http://127.0.0.1:3000";
+const API = import.meta.env.VITE_API_URL ?? "http://127.0.0.1:8000";
 
 export default function App() {
   const [health, setHealth] = useState("checking…");
@@ -27,6 +28,8 @@ export default function App() {
   const loadGuests = (eventId) =>
     getJSON(`${API}/guests/?event_id=${eventId}`).then(setGuests);
 
+  // load initial data
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { loadHealth(); loadEvents(); }, []);
 
   async function createEvent(e) {
@@ -74,24 +77,26 @@ export default function App() {
   }
 
   return (
-    <div style={{ maxWidth: 900, margin: "40px auto", fontFamily: "system-ui, sans-serif" }}>
+    <div className="container">
       <h1>QR Access Control — Front</h1>
-      <p>API: {API} | health: <b>{health}</b></p>
+      <p>
+        API: {API} | health: <b>{health}</b>
+      </p>
 
-      <section style={{ padding: 16, border: "1px solid #eee", borderRadius: 12, marginBottom: 16 }}>
+      <section className="section">
         <h2>Eventos</h2>
-        <form onSubmit={createEvent} style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        <form onSubmit={createEvent} className="form">
           <input
             placeholder="Nombre del evento"
             value={newEvent}
             onChange={(e) => setNewEvent(e.target.value)}
-            style={{ flex: 1, padding: 8 }}
+            className="input"
           />
-          <button disabled={busy}>Crear</button>
+          <button className="button" disabled={busy}>Crear</button>
         </form>
-        <ul>
-          {events.map(ev => (
-            <li key={ev.id} style={{ marginBottom: 6 }}>
+        <ul className="events-list">
+          {events.map((ev) => (
+            <li key={ev.id}>
               <button onClick={() => { setSelectedEvent(ev); loadGuests(ev.id); }}>
                 Seleccionar
               </button>{" "}
@@ -102,38 +107,46 @@ export default function App() {
       </section>
 
       {selectedEvent && (
-        <section style={{ padding: 16, border: "1px solid #eee", borderRadius: 12, marginBottom: 16 }}>
-          <h2>Invitados — Evento #{selectedEvent.id} · {selectedEvent.name}</h2>
+        <section className="section">
+          <h2>
+            Invitados — Evento #{selectedEvent.id} · {selectedEvent.name}
+          </h2>
 
-          <form onSubmit={createGuest} style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+          <form onSubmit={createGuest} className="form">
             <input
               placeholder="Nombre"
               value={guestForm.name}
               onChange={(e) => setGuestForm({ ...guestForm, name: e.target.value })}
-              style={{ flex: 1, padding: 8 }}
+              className="input"
             />
             <input
               placeholder="Email"
               value={guestForm.email}
               onChange={(e) => setGuestForm({ ...guestForm, email: e.target.value })}
-              style={{ flex: 1, padding: 8 }}
+              className="input"
               type="email"
             />
-            <button disabled={busy}>Añadir invitado</button>
+            <button className="button" disabled={busy}>Añadir invitado</button>
           </form>
 
-          <ul>
-            {guests.map(g => (
-              <li key={g.id} style={{ marginBottom: 8 }}>
+          <ul className="guest-list">
+            {guests.map((g) => (
+              <li key={g.id}>
                 <b>{g.name}</b> — {g.email} · token: <code>{g.token}</code>{" "}
-                <a href={`${API}/guests/qr/${g.id}.png`} target="_blank" rel="noreferrer">Ver QR</a>
+                <a href={`${API}/guests/qr/${g.id}.png`} target="_blank" rel="noreferrer">
+                  Ver QR
+                </a>
               </li>
             ))}
           </ul>
         </section>
       )}
 
-      {msg && <p><i>{msg}</i></p>}
+      {msg && (
+        <p>
+          <i>{msg}</i>
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- polish React front-end layout with dedicated CSS classes and correct default API URL
- validate and return 201 when creating events

## Testing
- `python -m pytest`
- `npm --prefix qrac run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af68ada5108326b7f7d5c9a8b4b087