### PR TITLE
Fix QR PNG generation failure by adding Pillow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+sqlmodel
+pydantic-settings
+qrcode[pil]


### PR DESCRIPTION
## Summary
- add FastAPI service dependencies to `requirements.txt`
- include `qrcode[pil]` so Pillow is installed for PNG QR generation

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
from app.services.qr import make_qr_png
print(len(make_qr_png('hello')))
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af70e719b483269245e0f2549da276