### PR TITLE
Add email send button for guest QR

### DIFF
--- a/.env
+++ b/.env
@@ -11,5 +11,6 @@ SMTP_PORT=587
 SMTP_USERNAME="usuario"
 SMTP_PASSWORD="password"
 SMTP_TLS=true
-MAIL_FROM="noreply@tu-dominio.com"
+# Dirección de correo que enviará los QR
+MAIL_FROM="jon.echeverriasanmillan@osakidetza.eus"
 MAIL_FROM_NAME="QR Access Control"

--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,6 @@ SMTP_PORT=587
 SMTP_USERNAME="usuario"
 SMTP_PASSWORD="password"
 SMTP_TLS=true
-MAIL_FROM="noreply@tu-dominio.com"
+# Dirección de correo que enviará los QR
+MAIL_FROM="jon.echeverriasanmillan@osakidetza.eus"
 MAIL_FROM_NAME="QR Access Control"

--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,8 @@ class Settings(BaseSettings):
     SMTP_USERNAME: str = ""
     SMTP_PASSWORD: str = ""
     SMTP_TLS: bool = True
-    MAIL_FROM: str = ""
+    # Dirección de correo que enviará los QR
+    MAIL_FROM: str = "jon.echeverriasanmillan@osakidetza.eus"
     MAIL_FROM_NAME: str = "QR Access Control"
 
     @field_validator("CORS_ORIGINS", mode="before")

--- a/qrac/src/App.jsx
+++ b/qrac/src/App.jsx
@@ -76,6 +76,18 @@ export default function App() {
     }
   }
 
+  async function sendQR(guestId) {
+    setBusy(true);
+    try {
+      await getJSON(`${API}/guests/${guestId}/resend`, { method: "POST" });
+      setMsg("QR enviado por email ✅");
+    } catch (err) {
+      setMsg(`Error enviando QR: ${err.message}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <div className="container">
       <h1>QR Access Control — Front</h1>
@@ -135,7 +147,10 @@ export default function App() {
                 <b>{g.name}</b> — {g.email} · token: <code>{g.token}</code>{" "}
                 <a href={`${API}/guests/qr/${g.id}.png`} target="_blank" rel="noreferrer">
                   Ver QR
-                </a>
+                </a>{" "}
+                <button onClick={() => sendQR(g.id)} disabled={busy}>
+                  Enviar QR por email
+                </button>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- add React button to email QR codes to guests
- set default sender address in config and environment files

## Testing
- `npm --prefix qrac run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af73558a34832689a4589d652c2abe