### PR TITLE
Fix aiosmtplib send call for QR emails

### DIFF
--- a/app/services/emailer.py
+++ b/app/services/emailer.py
@@ -29,7 +29,7 @@ async def send_qr_email(
     )
 
     await aiosmtplib.send(
-        message=msg,
+        msg,
         hostname=settings.SMTP_HOST,
         port=settings.SMTP_PORT,
         username=settings.SMTP_USERNAME,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 sqlmodel
 pydantic-settings
 qrcode[pil]
+aiosmtplib


### PR DESCRIPTION
## Summary
- fix QR email sending by passing message positionally to `aiosmtplib.send`
- add `aiosmtplib` to Python dependencies

## Testing
- `pytest -q`
- `python -m py_compile app/services/emailer.py`


------
https://chatgpt.com/codex/tasks/task_e_68af74cfd40c8326bbe09194f3fdd1dc