### PR TITLE
Handle missing SMTP configuration

### DIFF
--- a/.env
+++ b/.env
@@ -6,10 +6,12 @@ QR_BASE_URL="" # opcional, ej: https://tu-dominio.com (para que el QR apunte a /
 
 
 # SMTP (usa tu proveedor)
-SMTP_HOST="smtp.tu-proveedor.com"
+# Configura estas variables con los datos reales de tu servidor SMTP.
+# Si dejas `SMTP_HOST` en blanco, los correos no se enviarán.
+SMTP_HOST=""
 SMTP_PORT=587
-SMTP_USERNAME="usuario"
-SMTP_PASSWORD="password"
+SMTP_USERNAME=""
+SMTP_PASSWORD=""
 SMTP_TLS=true
 # Dirección de correo que enviará los QR
 MAIL_FROM="jon.echeverriasanmillan@osakidetza.eus"

--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,12 @@ QR_BASE_URL="" # opcional, ej: https://tu-dominio.com (para que el QR apunte a /
 
 
 # SMTP (usa tu proveedor)
-SMTP_HOST="smtp.tu-proveedor.com"
+# Configura estas variables con los datos reales de tu servidor SMTP.
+# Si dejas `SMTP_HOST` en blanco, los correos no se enviarán.
+SMTP_HOST=""
 SMTP_PORT=587
-SMTP_USERNAME="usuario"
-SMTP_PASSWORD="password"
+SMTP_USERNAME=""
+SMTP_PASSWORD=""
 SMTP_TLS=true
 # Dirección de correo que enviará los QR
 MAIL_FROM="jon.echeverriasanmillan@osakidetza.eus"

--- a/app/services/emailer.py
+++ b/app/services/emailer.py
@@ -12,7 +12,16 @@ async def send_qr_email(
     attachment_bytes: bytes,
     attachment_filename: str,
 ) -> None:
-    if not settings.SMTP_HOST or not settings.MAIL_FROM:
+    # Ensure SMTP settings are properly configured. The default value in
+    # the example `.env` uses a placeholder host (`smtp.tu-proveedor.com`).
+    # Treat this placeholder as missing configuration so the application
+    # fails fast with a clear error instead of trying to resolve a
+    # non-existent domain and raising a connection error.
+    if (
+        not settings.SMTP_HOST
+        or settings.SMTP_HOST == "smtp.tu-proveedor.com"
+        or not settings.MAIL_FROM
+    ):
         raise RuntimeError("SMTP settings are not configured")
 
     msg = EmailMessage()


### PR DESCRIPTION
## Summary
- validate SMTP settings before attempting to send emails
- clarify SMTP configuration in sample `.env`

## Testing
- `python -m py_compile app/services/emailer.py && echo 'py_compile ok'`


------
https://chatgpt.com/codex/tasks/task_e_68af768f137483269f0f67566ca8556e